### PR TITLE
Changes server data model to return unicode instead of utf-8 encoded string

### DIFF
--- a/datamodel/search/server_datamodel.py
+++ b/datamodel/search/server_datamodel.py
@@ -201,7 +201,7 @@ class Link(object):
                         and urlresp.status_code > 199
                         and urlresp.status_code < 300):
                     return self.__ProcessUrlData(
-                        urlresp.text.encode("utf-8"), self.user_agent_string)
+                        urlresp.text, self.user_agent_string)
                 elif size >= MaxPageSize:
                     self.error_reason = "Size too large."
                     return UrlResponse(


### PR DESCRIPTION
Requests detects the encoding using either the header tags or chardet library and creates a unicode string. Encoding it again in utf-8 would return a sequence of bytes encoded in utf-8 which can create a problem when using  lxml (https://stackoverflow.com/questions/11938924/parsing-utf-8-unicode-strings-with-lxml-html).